### PR TITLE
Add Github Repos in RAG

### DIFF
--- a/askracha/backend/README.md
+++ b/askracha/backend/README.md
@@ -5,6 +5,7 @@ This README covers only the backend setup (API + Qdrant via Docker Compose).
 ## 1) Prerequisites
 - Docker and Docker Compose
 - A valid Gemini API key
+- Run `./setup-repos.sh` in repos folder to clone the repos
 
 ## 2) Create .env (in this folder)
 Create a file named `.env` in `askracha/backend` with the following contents:

--- a/askracha/backend/cleaning/processors.py
+++ b/askracha/backend/cleaning/processors.py
@@ -1,0 +1,58 @@
+import os
+from typing import List, Dict
+from llama_index.core import Document
+
+class RepoProcessor:
+    """Processes GitHub repositories to extract meaningful content for RAG"""
+    
+    def __init__(self, repos_dir: str = "repos"):
+        """Initialize with path to repos directory"""
+        self.repos_dir = repos_dir
+        self.github_base_url = "https://github.com/storacha"
+        
+    def process_repos(self) -> List[Document]:
+        """Process all repositories in the repos directory"""
+        documents = []
+        
+        repo_dirs = [d for d in os.listdir(self.repos_dir) 
+                    if os.path.isdir(os.path.join(self.repos_dir, d)) and not d.startswith('.')]
+        
+        for repo_dir in repo_dirs:
+            repo_path = os.path.join(self.repos_dir, repo_dir)
+            repo_docs = self.process_repo_readmes(repo_path, repo_dir)
+            documents.extend(repo_docs)
+            
+        return documents
+    
+    def process_repo_readmes(self, repo_path: str, repo_name: str) -> List[Document]:
+        """Process all README files in a repository"""
+        documents = []
+        
+        for root, _, files in os.walk(repo_path):
+            for file in files:
+                if file.lower() == 'readme.md':
+                    file_path = os.path.join(root, file)
+                    try:
+                        with open(file_path, 'r', encoding='utf-8') as f:
+                            content = f.read()
+                            
+                        rel_path = os.path.relpath(file_path, repo_path)
+                        
+                        github_url = f"{self.github_base_url}/{repo_name}/blob/main/{rel_path}"
+                        
+                        doc = Document(
+                            text=content,
+                            metadata={
+                                'source': github_url,
+                                'type': 'readme',
+                                'repo': repo_name,
+                                'path': rel_path
+                            }
+                        )
+                        documents.append(doc)
+                        print(f"Processed README: {rel_path} from {repo_name}")
+                        
+                    except Exception as e:
+                        print(f"Error processing {file_path}: {e}")
+                        
+        return documents

--- a/askracha/backend/repos/.gitignore
+++ b/askracha/backend/repos/.gitignore
@@ -1,0 +1,1 @@
+upload-service/

--- a/askracha/backend/repos/setup-repos.sh
+++ b/askracha/backend/repos/setup-repos.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Clone/update repositories
+git clone https://github.com/storacha/upload-service.git
+# git clone https://github.com/storacha/ucanto.git # Skipping for now
+
+echo "upload-service/" >> .gitignore
+# echo "ucanto/" >> .gitignore
+


### PR DESCRIPTION
Closes #17 

Added GitHub repositories to the RAG system:
- Created cleaning module to process repository READMEs
- Integrated repo documents with existing documentation in the vector store
- Added clickable GitHub source URLs for better navigation
- Currently processing only README files, skipping package files as requested
